### PR TITLE
fix for crashy external Komodo as a kibitzer

### DIFF
--- a/Code/RunKibitzer.py
+++ b/Code/RunKibitzer.py
@@ -203,6 +203,8 @@ class VentanaMultiPV(QtGui.QDialog):
             if valor is None:
                 orden = "setoption name %s" % opcion
             else:
+                if type(valor) == bool:
+                    valor = str(valor).lower()
                 orden = "setoption name %s value %s" % (opcion, valor)
             self.ready_ok(orden)
 
@@ -697,6 +699,8 @@ class Ventana(QtGui.QDialog):
             else:
                 if opcion.upper() == "MULTIPV" and not siMultiPV:
                     continue
+                if type(valor) == bool:
+                    valor = str(valor).lower()
                 orden = "setoption name %s value %s" % (opcion, valor)
             self.ready_ok(orden)
 


### PR DESCRIPTION
Sending *True* instead of *true* could crash **Komodo 8** engine. For instance `setoption name Ponder value True`.