### PR TITLE
fixes bug in which GM xgm files cannot be found on Linux

### DIFF
--- a/Code/GM.py
+++ b/Code/GM.py
@@ -1,5 +1,6 @@
 import operator
 import os
+import sys
 
 from LCEngineV1 import xpv2pv, pv2xpv
 
@@ -67,7 +68,9 @@ class GM:
         return self.lastGame
 
     def read(self):
-        ficheroGM = self.gm + ".xgm"
+        #linux is case sensitive and can't find the xgm file because ficheroGM is all lower-case, but all
+        #the xgm files have the first letter capitalized (including ones recently downloaded)
+        ficheroGM = self.gm[0].upper() + self.gm[1:] + ".xgm"
         f = open(os.path.join(self.carpeta, ficheroGM), "rb")
         li = []
         for linea in f:


### PR DESCRIPTION
"Play like a Grandmaster" feature wasn't working (on Linux) because the xgm files are all capitalized, but GM.py is opening files with all lower case, and therefore couldn't be found on a case sensitive file system.

> Traceback (most recent call last):
  File "./Code/QT/PantallaGM.py", line 318, in aceptar
    if self.grabaDic():
  File "./Code/QT/PantallaGM.py", line 385, in grabaDic
    self.ogm = GM.GM(carpeta, rk.gm)
  File "./Code/GM.py", line 58, in __init__
    self.liGMPartidas = self.read()
  File "./Code/GM.py", line 71, in read 
    f = open(os.path.join(self.carpeta, ficheroGM), "rb")
IOError: [Errno 2] No such file or directory: u'GM/carlsen.xgm'

`